### PR TITLE
updated deno lambda event types

### DIFF
--- a/src/lambda/templates/events.js
+++ b/src/lambda/templates/events.js
@@ -6,9 +6,9 @@ exports.handler = async function subscribe (event) {
   return
 }`
 
-let deno = `import {Context, Event} from "https://deno.land/x/lambda/mod.ts"
+let deno = `import {Context, APIGatewayProxyEvent} from "https://deno.land/x/lambda/mod.ts"
 
-export async function handler(event: Event, context: Context) {
+export async function handler( event: APIGatewayProxyEvent, context: Context) {
   return {message: \`Welcome to deno \${Deno.version.deno} 🦕\`}
 }`
 

--- a/src/lambda/templates/http.js
+++ b/src/lambda/templates/http.js
@@ -1,14 +1,16 @@
 let learn = 'learn more about HTTP functions here: https://arc.codes/primitives/http'
 
-let deno = `import { Context, Event } from "https://deno.land/x/lambda/mod.ts";
+let deno = `import { Context, APIGatewayProxyEvent } from "https://deno.land/x/lambda/mod.ts";
 
-export async function handler(event: Event, context: Context) {
-  return {
-    statusCode: 200,
-    headers: {'content-type': 'text/html; charset=utf8'},
-    body: \`Welcome to deno \${Deno.version.deno} 🦕\`
-  };
-}`
+export async function handler(
+  event: APIGatewayProxyEvent,
+  context: Context) {
+    return {
+      statusCode: 200,
+      headers: {'content-type': 'text/html; charset=utf8'},
+      body: \`Welcome to deno \${Deno.version.deno} 🦕\`
+    };
+  }`
 
 function html (lang, ext) {
   return `

--- a/src/lambda/templates/queues.js
+++ b/src/lambda/templates/queues.js
@@ -6,9 +6,9 @@ exports.handler = async function queue (event) {
   return
 }`
 
-let deno = `import { Context, Event } from "https://deno.land/x/lambda/mod.ts"
+let deno = `import { Context, APIGatewayProxyEvent } from "https://deno.land/x/lambda/mod.ts"
 
-export async function handler(event: Event, context: Context) {
+export async function handler(event: APIGatewayProxyEvent, context: Context) {
   return {message: \`Welcome to deno \${Deno.version.deno} 🦕\`}
 }`
 

--- a/src/lambda/templates/scheduled.js
+++ b/src/lambda/templates/scheduled.js
@@ -6,9 +6,9 @@ exports.handler = async function scheduled (event) {
   return
 }`
 
-let deno = `import { Context, Event } from "https://deno.land/x/lambda/mod.ts"
+let deno = `import { Context, APIGatewayProxyEvent } from "https://deno.land/x/lambda/mod.ts"
 
-export async function handler(event: Event, context: Context) {
+export async function handler(event: APIGatewayProxyEvent, context: Context) {
   return {message: \`Welcome to deno \${Deno.version.deno} 🦕\`}
 }`
 

--- a/src/lambda/templates/tables.js
+++ b/src/lambda/templates/tables.js
@@ -6,9 +6,9 @@ exports.handler = async function table (event) {
   return
 }`
 
-let deno = `import {Context, Event} from "https://deno.land/x/lambda/mod.ts"
+let deno = `import {Context, APIGatewayProxyEvent} from "https://deno.land/x/lambda/mod.ts"
 
-export async function handler(event: Event, context: Context) {
+export async function handler(event: APIGatewayProxyEvent, context: Context) {
   return {message: \`Welcome to deno \${Deno.version.deno} 🦕\`}
 }`
 

--- a/src/lambda/templates/ws.js
+++ b/src/lambda/templates/ws.js
@@ -6,9 +6,9 @@ exports.handler = async function ws (req) {
   return {statusCode: 200}
 }`
 
-let deno = `import {Context, Event} from "https://deno.land/x/lambda/mod.ts"
+let deno = `import {Context, APIGatewayProxyEvent} from "https://deno.land/x/lambda/mod.ts"
 
-export async function handler(event: Event, context: Context) {
+export async function handler(event: APIGatewayProxyEvent, context: Context) {
   console.log(event)
   return {statusCode: 200}
 }`


### PR DESCRIPTION
Deno-lambda changed it's API for Event types, which caused an error in compilation. 
New event types for explicit `APIGatewayProxyEvent` instead of generic `Event`
