### PR TITLE
use globbing for tape and report coverage in npm run script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .git/
+.nyc_output/
+coverage/
 node_modules/
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "url": "git+https://github.com/architect/create.git"
   },
   "scripts": {
-    "test": "npm run lint && npm run test:unit",
-    "test:unit": "tape test/**/*-test.js | tap-spec",
+    "test": "npm run lint && npm run coverage",
+    "test:unit": "cross-env PORT=6666 tape 'test/unit/**/*-test.js' | tap-spec",
+    "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC"
   },
@@ -28,7 +29,9 @@
     "run-parallel": "~1.1.9"
   },
   "devDependencies": {
+    "cross-env": "~7.0.2",
     "eslint": "^7.0.0",
+    "nyc": "~15.1.0",
     "proxyquire": "^2.1.3",
     "tap-spec": "^5.0.0",
     "tape": "^5.0.1"


### PR DESCRIPTION
turns out close to 100% code coverage in this repo. noice