### PR TITLE
add support for `@plugins` pragma

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 ---
 
+## [1.4.0] 2021-03-22
+
+### Added
+
+- Added support for `@plugins` pragma
+  - This allows plugin authors to create new Lambdas
+
+---
+
 ## [1.3.4] 2021-03-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@architect/inventory": "~1.2.0",
+    "@architect/inventory": "~1.3.0-RC.0",
     "@architect/utils": "~2.0.2",
     "chalk": "~4.1.0",
     "run-parallel": "~1.2.0",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@architect/inventory": "~1.3.0-RC.1",
-    "@architect/utils": "~2.0.5-RC.0",
+    "@architect/inventory": "~1.3.1",
+    "@architect/utils": "~2.0.5",
     "chalk": "~4.1.0",
     "run-parallel": "~1.2.0",
     "run-series": "~1.1.9"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@architect/inventory": "~1.3.0-RC.0",
-    "@architect/utils": "~2.0.2",
+    "@architect/inventory": "~1.3.0-RC.1",
+    "@architect/utils": "~2.0.5-RC.0",
     "chalk": "~4.1.0",
     "run-parallel": "~1.2.0",
     "run-series": "~1.1.9"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "npm run lint && npm run coverage",
     "test:unit": "cross-env PORT=6666 tape 'test/unit/**/*-test.js' | tap-spec",
-    "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
+    "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -112,4 +112,34 @@ module.exports = async function create (params = {}, callback) {
   return promise
 }
 
+// In order to support nodejs v10
+// Stolen from https://stackoverflow.com/questions/53072385/array-prototype-flat-is-undefined-in-nodejs
+if (!Array.prototype.flat) {
+  Array.prototype.flat = function (maxDepth, currentDepth) {
+    let array = this
+    maxDepth = maxDepth === Infinity
+      ? Number.MAX_SAFE_INTEGER
+      : parseInt(maxDepth, 10) || 1
+    currentDepth = parseInt(currentDepth, 10) || 0
+
+    // It's not an array or it's an empty array, return the object.
+    if (!Array.isArray(array) || !array.length) {
+      return array
+    }
+
+    // If the first element is itself an array and we're not at maxDepth,
+    // flatten it with a recursive call first.
+    // If the first element is not an array, an array with just that element IS the
+    // flattened representation.
+    // **Edge case**: If the first element is an empty element/an "array hole", skip it.
+    // (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat#Examples)
+    let firstElemFlattened = (Array.isArray(array[0]) && currentDepth < maxDepth)
+      ? array[0].flat(maxDepth, currentDepth + 1)
+      : array[0] === undefined ? [] : [ array[0] ]
+
+    return firstElemFlattened.concat(array.slice(1).flat(maxDepth, currentDepth))
+  }
+}
+
+
 module.exports.bootstrap = bootstrap

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ module.exports = async function create (params = {}, callback) {
     if (scheduled)  functions.push(...scheduled.map(binder.scheduled))
     if (ws)         functions.push(...ws.map(binder.ws))
     if (streams)    functions.push(...streams.map(binder.streams))
-    if (Object.keys(plugins).length > 0) {
+    if (plugins) {
       functions.push(...Object.values(plugins).
         map(pluginModule => pluginModule.pluginFunctions).
         filter(functionMethod => functionMethod). // ensure plugin exports a `pluginFunctions` method; ignore ones that do not

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -14,7 +14,7 @@ let writeCode = require('./write-code')
  * @param {string} name - optional. of the format: hello-world-2020
  */
 module.exports = function code (params, callback) {
-  let { arcStaticAssetProxy, src, type, runtime, prefs } = params
+  let { arcStaticAssetProxy, src, type, runtime, prefs, body } = params
 
   // Immediate bail if source dir already exists
   if (arcStaticAssetProxy || existsSync(src)) {
@@ -38,7 +38,8 @@ module.exports = function code (params, callback) {
           writeCode({
             type,
             runtime,
-            handlerFile
+            handlerFile,
+            body
           }, callback)
         }
       },

--- a/src/lambda/write-code.js
+++ b/src/lambda/write-code.js
@@ -6,9 +6,9 @@ let ws = require('./templates/ws')
 let scheduled = require('./templates/scheduled')
 let streams = require('./templates/streams')
 
-module.exports = function writeCode ({ handlerFile, type, runtime }, callback) {
+module.exports = function writeCode ({ handlerFile, type, runtime, body }, callback) {
   let types = { http, events, queues, ws, scheduled, streams }
   let run = runtime.split(/\d/)[0]
-  let body = types[type][run]
+  body = body || types[type][run]
   writeFile(handlerFile, body, callback)
 }

--- a/test/unit/src/index-test.js
+++ b/test/unit/src/index-test.js
@@ -20,16 +20,13 @@ test('Should invoke code-writing module for @plugin functions', t => {
         preferences: {},
         defaultFunctionConfig: { runtime: 'nodejs12' }
       },
-      plugins: {
-        someplugin: {
-          pluginFunctions: function () {
-            return [ {
-              src: 'some/path/to/new/lambda',
-              body: 'molded by it'
-            } ]
-          }
+      plugins: [
+        {
+          src: '/some/path/to/project/src/new/lambda',
+          name: 'new-lambda',
+          body: 'molded by it'
         }
-      }
+      ]
     }
   }
   create({
@@ -39,9 +36,9 @@ test('Should invoke code-writing module for @plugin functions', t => {
   }, (err) => {
     t.notOk(err, 'Did not error')
     let codeArg = args[0]
-    t.equals(codeArg.src, 'some/path/to/new/lambda', 'Path to new plugin function passed to code writing module')
+    t.equals(codeArg.src, '/some/path/to/project/src/new/lambda', 'Path to new plugin function passed to code writing module')
     t.equals(codeArg.body, 'molded by it', 'Body of new plugin function passed to code writing module')
-    t.equals(codeArg.type, 'plugin', 'New plugin function has a type of plugin passed to code writing module')
+    t.equals(codeArg.type, 'plugins', 'New plugin function has a type of plugin passed to code writing module')
   })
 })
 

--- a/test/unit/src/index-test.js
+++ b/test/unit/src/index-test.js
@@ -44,3 +44,26 @@ test('Should invoke code-writing module for @plugin functions', t => {
     t.equals(codeArg.type, 'plugin', 'New plugin function has a type of plugin passed to code writing module')
   })
 })
+
+test('Should not error if @plugins does not exist in inventory', t => {
+  t.plan(1)
+  let update = {
+    done: () => {}
+  }
+  let inventory = {
+    inv: {
+      _project: {
+        preferences: {},
+        defaultFunctionConfig: { runtime: 'nodejs12' }
+      },
+    }
+  }
+  create({
+    standalone: true,
+    inventory,
+    update
+  }, (err) => {
+    t.notOk(err, 'Did not error')
+  })
+})
+

--- a/test/unit/src/index-test.js
+++ b/test/unit/src/index-test.js
@@ -1,0 +1,46 @@
+let proxyquire = require('proxyquire')
+let args = []
+let codeStub = (params, cb) => {
+  args.push(params)
+  cb()
+}
+let create = proxyquire('../../../src', {
+  './lambda': codeStub
+})
+let test = require('tape')
+
+test('Should invoke code-writing module for @plugin functions', t => {
+  t.plan(4)
+  let update = {
+    done: () => {}
+  }
+  let inventory = {
+    inv: {
+      _project: {
+        preferences: {},
+        defaultFunctionConfig: { runtime: 'nodejs12' }
+      },
+      plugins: {
+        someplugin: {
+          pluginFunctions: function () {
+            return [ {
+              src: 'some/path/to/new/lambda',
+              body: 'molded by it'
+            } ]
+          }
+        }
+      }
+    }
+  }
+  create({
+    standalone: true,
+    inventory,
+    update
+  }, (err) => {
+    t.notOk(err, 'Did not error')
+    let codeArg = args[0]
+    t.equals(codeArg.src, 'some/path/to/new/lambda', 'Path to new plugin function passed to code writing module')
+    t.equals(codeArg.body, 'molded by it', 'Body of new plugin function passed to code writing module')
+    t.equals(codeArg.type, 'plugin', 'New plugin function has a type of plugin passed to code writing module')
+  })
+})

--- a/test/unit/src/lambda/write-code-test.js
+++ b/test/unit/src/lambda/write-code-test.js
@@ -1,0 +1,41 @@
+let proxyquire = require('proxyquire')
+let destination
+let written
+let fsStub = {
+  writeFile: (dest, data, cb) => {
+    destination = dest
+    written = data
+    cb()
+  }
+}
+let writeCode = proxyquire('../../../../src/lambda/write-code', {
+  fs: fsStub
+})
+let test = require('tape')
+
+test('Set up env', t => {
+  t.plan(1)
+  t.ok(writeCode, 'Loaded writeCode')
+})
+
+test('Should write body if provided via argument', t => {
+  t.plan(2)
+  writeCode({
+    handlerFile: 'src/lambda/index.js',
+    runtime: 'nodejs12',
+    body: 'this is bat country'
+  }, () => {})
+  t.equal(destination, 'src/lambda/index.js', 'Correct file location to be written to')
+  t.equal(written, 'this is bat country', 'Correct argument-provided content written')
+})
+
+test('Should write template body if no body provided via argument', t => {
+  t.plan(2)
+  writeCode({
+    handlerFile: 'src/http/get-catchall/index.js',
+    runtime: 'nodejs12',
+    type: 'http'
+  }, () => {})
+  t.equal(destination, 'src/http/get-catchall/index.js', 'Correct file location to be written to')
+  t.match(written, /async function http/, 'Correct argument-provided content written')
+})


### PR DESCRIPTION
plugins can create new lambdas based on output of a `pluginFunctions` method.

Setting this as a draft PR until all the other PRs for the other core arc packages are ready as well.

Relevant content:

- The Plugin Authoring docs PR is here: architect/arc.codes#324
- The original RFC is here: architect/architect#1062