### PR TITLE
check plugins exists instead of checking plugins has keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ module.exports = async function create (params = {}, callback) {
     if (scheduled)  functions.push(...scheduled.map(binder.scheduled))
     if (ws)         functions.push(...ws.map(binder.ws))
     if (streams)    functions.push(...streams.map(binder.streams))
-    if (Object.keys(plugins).length > 0) {
+    if (plugins) {
       functions.push(...Object.values(plugins).
         map(pluginModule => pluginModule.pluginFunctions).
         filter(functionMethod => functionMethod). // ensure plugin exports a `pluginFunctions` method; ignore ones that do not

--- a/test/unit/src/index-test.js
+++ b/test/unit/src/index-test.js
@@ -44,3 +44,26 @@ test('Should invoke code-writing module for @plugin functions', t => {
     t.equals(codeArg.type, 'plugin', 'New plugin function has a type of plugin passed to code writing module')
   })
 })
+
+test('Should not error if @plugins does not exist in inventory', t => {
+  t.plan(1)
+  let update = {
+    done: () => {}
+  }
+  let inventory = {
+    inv: {
+      _project: {
+        preferences: {},
+        defaultFunctionConfig: { runtime: 'nodejs12' }
+      },
+    }
+  }
+  create({
+    standalone: true,
+    inventory,
+    update
+  }, (err) => {
+    t.notOk(err, 'Did not error')
+  })
+})
+


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!

Hey just a tiny bugfix for this issue 

<img width="1401" alt="image" src="https://user-images.githubusercontent.com/7361428/109813958-e9053980-7c25-11eb-809f-c4eced409891.png">

I don't know if it would be better to check that plugins exists and has keys but this fix was simpler and made the tests pass. If you want both conditions like below just say and I will change it

```javascript
if(plugins && Object.keys(plugins).length > 0) {}

