### PR TITLE
Fix project creation for fresh projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage/
 node_modules/
 package-lock.json
+test/tmp

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [1.4.1] 2021-03-25
+
+### Fixed
+
+- Fixed project structure and basic file creation when initializing a fresh new project; fixes [#1078](https://github.com/architect/architect/issues/1078)
+
+---
+
 ## [1.4.0] 2021-03-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "url": "git+https://github.com/architect/create.git"
   },
   "scripts": {
-    "test": "npm run lint && npm run coverage",
+    "test": "npm run lint && npm run test:integration && npm run coverage",
     "test:unit": "cross-env PORT=6666 tape 'test/unit/**/*-test.js' | tap-spec",
+    "test:integration": "cross-env tape 'test/integration/**/*-test.js' | tap-spec",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC"
@@ -32,6 +33,7 @@
     "@architect/eslint-config": "1.0.0",
     "cross-env": "~7.0.3",
     "eslint": "^7.14.0",
+    "fs-extra": "~9.1.0",
     "nyc": "~15.1.0",
     "proxyquire": "^2.1.3",
     "tap-spec": "^5.0.0",

--- a/src/bootstrap/_get-name.js
+++ b/src/bootstrap/_get-name.js
@@ -4,13 +4,14 @@ module.exports = function getProjectName ({ options = [], update }) {
   // Known options
   let isVerbose = opt => opt === 'verbose' || opt === '--verbose' || opt === '-v'
   let isRuntime = opt => opt === 'runtime' || opt === '--runtime' || opt === '-r'
+  let isNoInstall = opt => opt === 'noinstall' || opt === '--no-install' || opt === '-n'
 
   // Grab runtime value for filtering
   let runtime = options.findIndex(isRuntime) === -1 ? null : options.findIndex(isRuntime) + 1
   // Filter known options from arg list
   let filtered = options.filter((opt, i) => {
     if (i === runtime) return false
-    if (isVerbose(opt) || isRuntime(opt)) return false
+    if (isVerbose(opt) || isRuntime(opt) || isNoInstall(opt)) return false
     return true
   })
   let passedName = filtered[filtered.length - 1] || ''

--- a/test/integration/cli-test.js
+++ b/test/integration/cli-test.js
@@ -1,0 +1,52 @@
+let test = require('tape')
+let cli = require('../../cli')
+let { join } = require('path')
+let fs = require('fs-extra')
+let { readFileSync, existsSync } = require('fs')
+let tmp = join(__dirname, '..', 'tmp')
+let origCwd = process.cwd()
+
+test('integration test setup', async t => {
+  t.plan(1)
+  await fs.emptyDir(tmp)
+  process.chdir(tmp)
+  t.pass('integration test environment setup complete')
+})
+
+test('should build the basic templated node runtime project', async t => {
+  t.plan(2)
+  fs.emptyDirSync(tmp)
+  await cli([ '--no-install', '--runtime', 'node' ])
+  t.ok(existsSync(join(tmp, 'src', 'http', 'get-index', 'index.js')), 'src/http/get-index/index.js created')
+  t.ok(readFileSync(join(tmp, 'app.arc'), 'utf-8').match(/runtime node/), '"runtime node" present somewhere in manifest')
+})
+
+test('should build the basic templated deno runtime project', async t => {
+  t.plan(2)
+  fs.emptyDirSync(tmp)
+  await cli([ '--no-install', '--runtime', 'deno' ])
+  t.ok(existsSync(join(tmp, 'src', 'http', 'get-index', 'index.ts')), 'src/http/get-index/index.ts created')
+  t.ok(readFileSync(join(tmp, 'app.arc'), 'utf-8').match(/runtime deno/), '"runtime deno" present somewhere in manifest')
+})
+
+test('should build the basic templated python runtime project', async t => {
+  t.plan(2)
+  fs.emptyDirSync(tmp)
+  await cli([ '--no-install', '--runtime', 'python' ])
+  t.ok(existsSync(join(tmp, 'src', 'http', 'get-index', 'index.py')), 'src/http/get-index/index.py created')
+  t.ok(readFileSync(join(tmp, 'app.arc'), 'utf-8').match(/runtime python/), '"runtime python" present somewhere in manifest')
+})
+
+test('should build the basic templated ruby runtime project', async t => {
+  t.plan(2)
+  fs.emptyDirSync(tmp)
+  await cli([ '--no-install', '--runtime', 'ruby' ])
+  t.ok(existsSync(join(tmp, 'src', 'http', 'get-index', 'index.rb')), 'src/http/get-index/index.rb created')
+  t.ok(readFileSync(join(tmp, 'app.arc'), 'utf-8').match(/runtime ruby/), '"runtime ruby" present somewhere in manifest')
+})
+
+test('integration test teardown', t => {
+  t.plan(1)
+  process.chdir(origCwd)
+  t.pass('integration test environment setup removed')
+})

--- a/test/unit/cli-test.js
+++ b/test/unit/cli-test.js
@@ -1,0 +1,26 @@
+let proxyquire = require('proxyquire')
+let test = require('tape')
+let bootstrapFake = { install: true }
+let nameFake = { folder: '/some/path/to/project' }
+let invFake = {
+  inv: {
+    _project: {
+      preferences: {},
+      defaultFunctionConfig: { runtime: 'nodejs12' }
+    }
+  }
+}
+let staticCallCount = 0
+let cli = proxyquire('../../cli', {
+  './src/bootstrap/_banner': () => {},
+  './src/bootstrap': () => bootstrapFake,
+  './src/bootstrap/_get-name': () => nameFake,
+  '@architect/inventory': () => Promise.resolve(invFake),
+  './src/simple-static': () => { staticCallCount++ }
+})
+
+test('should invoke static module if static option provided', async t => {
+  t.plan(1)
+  await cli([ '--static' ])
+  t.equals(staticCallCount, 1, 'static module called when static option provided')
+})


### PR DESCRIPTION
This relates to https://github.com/architect/architect/issues/1078

For fresh new projects, we need to re-seed the inventory after creating the application manifest but before delegating to the rest of the create module to create any function directories, otherwise the stale (unpopulated) inventory gets passed to the modules doing the directory and file creating.

This also adds some integration tests for basic project creation.

This also adds a stealth `--no-install` flag to create in case you don't want the package manager getting all up in your face; no specific use case, just for faster test execution at the moment.