### PR TITLE
Fix CLI `init` alias creating directories called `init`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [3.0.1] 2021-10-28
+
+### Fixed
+
+- Fixed CLI `init` alias creating directories called `init`
+
+---
+
 ## [3.0.0] 2021-10-17
 
 ### Added

--- a/cli.js
+++ b/cli.js
@@ -28,7 +28,7 @@ async function cmd (opts = {}) {
   let string = [ 'name', 'runtime' ]
   let args = minimist(process.argv.slice(2), { alias, string })
   let { _ } = args
-  if ([ 'create', '@architect' ].includes(_[0])) _.splice(0, 1)
+  if ([ '@architect', 'create', 'init' ].includes(_[0])) _.splice(0, 1)
 
   let install = opts.install
   if (typeof args.install === 'boolean') install = args.install


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
